### PR TITLE
chore: improve the issue tracker process

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,35 @@
+# The "request-info" app is used to automatically alert users when they have created a
+# new issues that does not have any description. We will reassure them that we need information
+# to be able to help them. It will also say they should follow the issue template that was
+# pre-provided when creating the issue.
+
+requestInfoReplyComment: >
+  Thank you for your submission, however, with the lack of information, we are unable
+  to continue at this time.
+
+  We would appreciate it if you could provide us with more information about this
+  submission so that we could provide better support to this issue/pr.
+
+  Therefore, please edit this issue accordingly by using our pre-provided template or
+  close and create a new one and make sure to provide all the required information.
+
+  This submission will be automatically closed later if no information is provided.
+
+# Titles can also be checked against for lack of descriptiveness. (MUST BE ALL LOWERCASE)
+# requestInfoDefaultTitles:
+#   - update readme.md
+#   - updates
+
+# Append the info-needed label issues and prs with insufficient information.
+requestInfoLabelToAdd: info-needed
+
+# Issues and PR requires more information than what is provided in the templates
+# This check will will fail if the body matches the provided template
+checkIssueTemplate: true
+checkPullRequestTemplate: true
+
+# Only warn about insufficient information on these events types
+# Keys must be lowercase. Valid values are 'issue' and 'pullRequest'
+requestInfoOn:
+  pullRequest: true
+  issue: true

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,26 @@
+# The "lock" app is used to lock the threads of a closed issues or prs after (x) number of days of inactivity.
+# This is to help prevent long-lived issues and prs after being resolved. If users still have issues after
+# a closed PR or issue thread is locked, they should create a new issue. The locking of the thread does not
+# occur immedatly after an issue or PR is closed. Users will still have an opportunity to re-open the issue.
+# They can always back-link to an old locked issue in a new issue if they believe it is the one and the same.
+
+# The number of days of inactivity before a closed issue or pr is locked
+daysUntilLock: 14
+
+# Skip issues and prs created before a given timestamp. ISO 8601 Timestamp `YYYY-MM-DD` or `false` to disable
+skipCreatedBefore: false
+
+# Issues and pr with these labels will be ignored. `[]` to disable
+exemptLabels: []
+
+# The label to add before locking. `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,20 @@
+# The "no-response" app is used to automatically close issues that have not received a response
+# from the author. This app is paired with the "request-info" app which manages the warning
+# and label pinning.
+
+# Notice: This app does not support PRs. While the "request-info" app still warns users in PRs,
+# PRs will need to be managed manually for the closing.
+
+# The number of days of inactivity before an issue is closed for lack of response
+daysUntilClose: 4
+
+# The pinned label requiring a response
+responseRequiredLabel: info-needed
+
+# Comment to post when closing an issue for lack of response. `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+# The "Stale" app is used to automatically close stale issues and pr which accumulates over time.
+
+# The number of days of inactivity before an issue or pr is flagged as stale with the stale tag.
+daysUntilStale: 60
+
+# The number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+
+# The issues and pr that contains any of these labels will never be flagged as stale
+exemptLabels:
+  - pinned
+  - security
+
+# The label which is appened to mark an issue or pr as stale
+staleLabel: wontfix
+
+# Below is the stale bot's comment to warn users when a issue or pr becomes stale.
+markComment: >
+This has been automatically marked as stale due to the lack of activity. It will be closed if no further activity occurs.
+
+If you believe this is still valid, please provide an update to reassure that it is needed and all open questions were answered.
+When verifying, please use the master branch as this may have already been resolved.
+
+Thank you for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
### Motivation, Context & Description

Improve the issue tracker process by using Probot apps to manage certain tedious tasks.

* Please see mailing thread for detail discussion.
* Please comment freely on the setting values here as well.

## Overview based on settings

**For proper Issues & PRs**

- After 2 months of no activity, the issue/pr will become stale and the thread will be warned. A "stale" label is appended.
- After 2 weeks of being stale, and continues to have no activity, the issue/pr is closed.
- After 2 weeks of being closed, and continues to have no activity, the issue/pr thread will become locked.

In total, this process covers ~3 months. (88 days exactly). After being flagged stale, users have still enough time to create an activity to prevent the app from closing and locking the thread.

Additionally, I have also declared labels of "security" and "pinned" to be ignored by the app so it will never go stale.

**For issues & PRs that have no description or matches the template.**

- Shortly after the submission of a bad issue or pr, the app will post a warning that information must be provided. Also, "info-needed" label is applied
- After 4 days of no response, the bot will close the issue. (PR will need to be manually managed for now)
- After 2 weeks of being closed,  and continues to have no activity, the issue/pr thread will become locked.

In total, this process covers ~18 days. The author of the ticket will have enough time to correct the issue before the app closes and locks the thread.