### PR TITLE
Removed deprecation text for plugins that have been undeprecated

### DIFF
--- a/deprecated.md
+++ b/deprecated.md
@@ -36,20 +36,6 @@ Apache Cordova is a relatively old project. As such, we deprecated serveral of o
 - Deprecation announcement: https://cordova.apache.org/news/2017/11/27/Deprecation-of-cordova-contacts-plugin.html
 - Reason: various privacy and security issues
 
-### [cordova-plugin-device-motion](https://github.com/apache/cordova-plugin-device-motion)
-
-- Date: 2017-09
-- Deprecation announcement: https://cordova.apache.org/news/2017/09/22/plugins-release.html
-- Reason: The [W3C Device Motion and Orientation API](https://www.w3.org/TR/2016/CR-orientation-event-20160818/#devicemotion) now defines a way to access the accelerometer of the device
-- Migration Guide: https://blog.phonegap.com/migrating-from-the-cordova-device-motion-plugin-ddd8176632ed
-
-### [cordova-plugin-device-orientation](https://github.com/apache/cordova-plugin-device-orientation)
-
-- Date: 2017-09
-- Deprecation announcement: https://cordova.apache.org/news/2017/09/22/plugins-release.html
-- Reason: The [W3C Device Motion and Orientation API](https://www.w3.org/TR/2016/CR-orientation-event-20160818/#devicemotion) now defines a way to access the compass of the device
-- Migration Guide: https://blog.phonegap.com/migrating-from-the-cordova-device-orientation-plugin-8442b869e6cc
-
 ### [cordova-plugin-globalization](https://github.com/apache/cordova-plugin-globalization)
 
 - Date: 2017-11

--- a/deprecated.md
+++ b/deprecated.md
@@ -50,12 +50,6 @@ Apache Cordova is a relatively old project. As such, we deprecated serveral of o
 - Reason: The [W3C Device Motion and Orientation API](https://www.w3.org/TR/2016/CR-orientation-event-20160818/#devicemotion) now defines a way to access the compass of the device
 - Migration Guide: https://blog.phonegap.com/migrating-from-the-cordova-device-orientation-plugin-8442b869e6cc
 
-### [cordova-plugin-file-transfer](https://github.com/apache/cordova-plugin-file-transfer)
-
-- Date: 2017-10
-- Reason: `XMLHttpRequest` supports [download of binary data](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data) on all relevant platforms and browsers
-- Deprecation announcement and transition guide: https://cordova.apache.org/blog/2017/10/18/from-filetransfer-to-xhr2.html
-
 ### [cordova-plugin-globalization](https://github.com/apache/cordova-plugin-globalization)
 
 - Date: 2017-11


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

N/A

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Removes the deprecation text blocks for the following plugins  as it was decided to bring those plugins back from the dead:

- cordova-plugin-file-transfer
- cordova-plugin-device-orientation
- cordova-plugin-device-motion

### Description
<!-- Describe your changes in detail -->

I simply deleted the text blocks. Not sure if it's worth keeping this text at all, don't think it is, but definitely could be discussed if felt differently.

### Testing
<!-- Please describe in detail how you tested your changes. -->

N/A

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
