### PR TITLE
Add wkwebview-engine plugin to deprecated list

### DIFF
--- a/deprecated.md
+++ b/deprecated.md
@@ -42,6 +42,12 @@ Apache Cordova is a relatively old project. As such, we deprecated serveral of o
 - Reason: Replacement [ECMA Internationalization API](https://www.ecma-international.org/ecma-402/1.0/) available in all relevant platforms
 - Deprecation announcement and Migration guide: https://cordova.apache.org/news/2017/11/20/migrate-from-cordova-globalization-plugin.html
 
+### [cordova-plugin-wkwebview-engine](https://github.com/apache/cordova-plugin-wkwebview-engine)
+
+- Date: 2021-02
+- Reason: WKWebView implementation is now provided by [cordova-ios@6](https://cordova.apache.org/announcements/2020/06/01/cordova-ios-release-6.0.0.html) making this plugin obsolete.
+- Deprecation announcement and Migration guide: https://cordova.apache.org/2021/02/07/deprecate-wkwebview-engine.html
+
 ### [cordova-plugin-legacy-whitelist](https://github.com/apache/cordova-plugin-legacy-whitelist)
 
 ## Deprecated Tooling


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

WKWebview engine plugin is now deprecated.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
