### PR TITLE
chore(asf.yml): Flag GitHub Discussions as enabled

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,6 +33,7 @@ github:
     wiki: false
     issues: true
     projects: true
+    discussions: true
   
   enabled_merge_buttons:
     squash: true


### PR DESCRIPTION
I think we might already be safely opted-in because we have a `'discussions'` entry in the notifications section, but just to be safe we should explicitly enable it as a feature.