### PR TITLE
doc(readme): replace Cordova repositories graph with Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,36 @@ To file a bug, or raise another type of issue, please navigate to the appropriat
 
 All Cordova code is hosted in repositories on GitHub.
 
-[![Cordova Dependency Graph](https://sketchviz.com/@raphinesse/a6f28acb2281b782d9fb5ef486834deb/fbb1d0715431bdd67a9bc430a8d0a9899b145bf9.sketchy.png)](//sketchviz.com/@raphinesse/a6f28acb2281b782d9fb5ef486834deb)
+```mermaid
+graph TD
+    cli --> lib
+    cli --> create
+    cli --> common
+
+    plugman --> lib
+
+    lib --> fetch
+    lib --> serve
+    lib --> common
+    lib -.-> platforms
+
+    create --> fetch
+    create --> app-hello-world
+    create --> common
+
+    fetch --> common
+
+    platforms["`Platforms
+      *
+      android
+      ios, osx
+      browser`"]
+
+    platforms -->|ios, osx| node-xcode
+    platforms -->|browser| serve
+    platforms -->|all| common
+    platforms -.->|all| js
+```
 
 Continuous Integration status of all relevant repositories: https://apache.github.io/cordova-status/
 

--- a/README.md
+++ b/README.md
@@ -19,33 +19,28 @@ All Cordova code is hosted in repositories on GitHub.
 
 ```mermaid
 graph TD
-    cli --> lib
-    cli --> create
     cli --> common
+
+    create --> common
+    create --> app-hello-world
+    create --> fetch
+    
+    fetch --> common
+    
+    lib --> fetch
+    lib --> common
+    lib -.-> platforms
+    
+    cli --> create
+    cli --> lib
 
     plugman --> lib
 
-    lib --> fetch
-    lib --> serve
-    lib --> common
-    lib -.-> platforms
-
-    create --> fetch
-    create --> app-hello-world
-    create --> common
-
-    fetch --> common
-
-    platforms["`Platforms
-      *
-      android
-      ios, osx
-      browser`"]
-
-    platforms -->|ios, osx| node-xcode
-    platforms -->|browser| serve
     platforms -->|all| common
     platforms -.->|all| js
+    platforms -->|browser| serve
+    platforms -->|ios| node-xcode
+    platforms["Platforms<br/>android | browser | ios"]
 ```
 
 Continuous Integration status of all relevant repositories: https://apache.github.io/cordova-status/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To file a bug, or raise another type of issue, please navigate to the appropriat
 All Cordova code is hosted in repositories on GitHub.
 
 ```mermaid
+---
+config:
+  look: handDrawn
+---
 graph TD
     cli --> common
 


### PR DESCRIPTION
GitHub Markdown has built-in functionality for creating diagrams: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams. This can be used instead of using a third party solution.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
